### PR TITLE
Fix syntax error in async-map-ordered.js

### DIFF
--- a/lib/async-map-ordered.js
+++ b/lib/async-map-ordered.js
@@ -62,4 +62,4 @@ function flip (res, resCount, argLen) {
   var flat = []
   // res = [[er, x, y], [er, x1, y1], [er, x2, y2, z2]]
   // return [[x, x1, x2], [y, y1, y2], [undefined, undefined, z2]]
-  
+}


### PR DESCRIPTION
Missing `}` is causing syntax error when this file is required.